### PR TITLE
Set required Python to 3.7

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.7"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Goals:
 
 ## Installation for developers
 
+Only Python 3.7.x is tested and supported.
+
 1. Clone the repo
 2. Run `pip install -e .` to install all dependencies with pip.
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     packages=['vote_tally'], # the location of the module
     version=0.1,
     install_requires=get_requirements(),
-    python_requires='>=3.7',
+    python_requires='==3.7.*',
     entry_points={'console_scripts':['vtally= vote_tally:main']}
 )


### PR DESCRIPTION
This is what we're all using and it turns out it DOESN'T work on Python 3.11 (pandas 2.x) so this is what we're doing :D 